### PR TITLE
Add "ADDITIONAL_PKGS" env var to Jenkins template

### DIFF
--- a/binhex/jenkins.xml
+++ b/binhex/jenkins.xml
@@ -42,10 +42,17 @@
     <Variable>
       <Name>JAVA_ARGS</Name>
       <Value>-Xmx512m</Value>
+      <Description>Java arguments</Description>
     </Variable>
     <Variable>
       <Name>JAVA_OPTS</Name>
       <Value>-Dhudson.footerURL=http://mycompany.com</Value>
+      <Description>Java options</Description>
+    </Variable>
+    <Variable>
+      <Name>ADDITIONAL_PKGS</Name>
+      <Value></Value>
+      <Description>Space-separated list of Pacman packages to install</Description>
     </Variable>
     <Variable>
       <Name>UMASK</Name>


### PR DESCRIPTION
This PR just adds [the environment variable ADDITIONAL_PKGS](https://github.com/binhex/arch-jenkins/pull/7) to the Jenkins template. Space-separated list allows container maintainers to specify additional packages to be installed for Jenkins. Specifically for my needs, I need NPM installed to perform builds (no benefit from setting up separate instances of Jenkins, very barebones use case)