### PR TITLE
Update MakeMKV project link

### DIFF
--- a/binhex/makemkv.xml
+++ b/binhex/makemkv.xml
@@ -12,7 +12,7 @@
     <GitHub>https://github.com/binhex/arch-makemkv</GitHub>
     <ReadMe>https://github.com/binhex/documentation</ReadMe>
     <Support>https://forums.unraid.net/topic/80994-support-binhex-makemkv/</Support>
-    <Project>https://www.makemkv.org/download/makemkv/</Project>
+    <Project>https://www.makemkv.com/</Project>
     <Overview>MakeMKV is your one-click solution to convert video that you own into free and patents-unencumbered format that can be played everywhere. MakeMKV is a format converter, otherwise called "transcoder". It converts the video clips from proprietary (and usually encrypted) disc into a set of MKV files, preserving most information but not changing it in any way. The MKV format can store multiple video/audio tracks with all meta-information and preserve chapters. There are many players that can play MKV files nearly on all platforms, and there are tools to convert MKV files to many formats, including DVD and Blu-ray discs.</Overview>
     <WebUI>http://[IP]:[PORT:6080]/vnc.html?resize=remote&amp;host=[IP]&amp;port=[PORT:6080]&amp;autoconnect=1</WebUI>
     <TemplateURL>https://raw.githubusercontent.com/binhex/docker-templates/master/binhex/makemkv.xml</TemplateURL>


### PR DESCRIPTION
makemkv.org is no longer a valid URL (taken over and goes to random advertising).  makemkv.com is correct